### PR TITLE
Improve bin wrapper generation in install script

### DIFF
--- a/bin_templ
+++ b/bin_templ
@@ -2,4 +2,4 @@
 
 source "$(dirname ${0})"/../env
 
-bundle exec "@BINFILE@" $*
+bundle exec "${BASE_DIR}/@BINFILE@" $*

--- a/bin_templ
+++ b/bin_templ
@@ -2,4 +2,4 @@
 
 source "$(dirname ${0})"/../env
 
-bundle exec "${BASE_DIR}/vendor/bin/$(basename ${0})" $*
+bundle exec "@BINFILE@" $*

--- a/install.sh
+++ b/install.sh
@@ -15,22 +15,22 @@ export RBENV_DIR=$BASE_DIR
 
 rm -rf bin
 
-bundle config --local path vendor/bundler
-bundle config --local bin vendor/bin
-bundle config build.ffi-yajl --with-ldflags="-Wl,-undefined,dynamic_lookup"
+bundle config set --local jobs '4'
+bundle config set --local path vendor/bundler
+bundle config set build.ffi-yajl --with-ldflags="-Wl,-undefined,dynamic_lookup"
+
 if [ -d vendor/bundler ]; then
     rm -rf vendor/bundler
 fi
 bundle install --local
 bundle clean
 
-# for rubocop-daemon
-cp vendor/bundler/ruby/*/gems/rubocop-daemon-*/bin/rubocop-daemon-wrapper vendor/bin/
-
 mkdir bin
 
-for bin_file in $(ls vendor/bin); do
-    cp bin_templ bin/$(basename $bin_file)
+for bin_file in vendor/bundler/ruby/*/bin/*; do
+    bin_name=$(basename $bin_file)
+    sed "s|@BINFILE@|$bin_file|g" bin_templ >"bin/$bin_name"
+    chmod +x "bin/$bin_name"
 done
 
 if [ -f bin/bundle ]; then


### PR DESCRIPTION
## Summary

- Change `bin_templ` to use `@BINFILE@` placeholder, replaced by `sed` during install with the actual gem binary path
- Update `bundle config` commands from deprecated syntax to modern `set` subcommand syntax
- Add `bundle config set --local jobs '4'` for parallel installation
- Remove hardcoded rubocop-daemon-wrapper copy step
- Replace `ls vendor/bin` with direct glob over bundler's gem bin directory

## Why

The previous approach relied on `bundle config --local bin` to generate executables in `vendor/bin`, then copied `bin_templ` over them. This depended on deprecated bundle config syntax, indirect file discovery via `ls vendor/bin`, and a fragile hardcoded copy of rubocop-daemon-wrapper.

## How

Introduced a `@BINFILE@` placeholder in `bin_templ` and used `sed` substitution in the install loop to embed the actual gem bin path into each wrapper script. This eliminates the dependency on `bundle binstubs` and provides a more direct and robust wrapper generation approach.