### PR TITLE
install.sh で asdf install を実行するようにする

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,8 @@ popd >/dev/null
 export BUNDLE_GEMFILE=$BASE_DIR/Gemfile
 export RBENV_DIR=$BASE_DIR
 
+asdf install
+
 rm -rf bin
 
 bundle config set --local jobs '4'


### PR DESCRIPTION
## 概要

install.sh の冒頭で asdf install を呼び出し、.tool-versions に記載された Ruby バージョンが bundle install 実行前に確実にインストールされるようにする。

## 変更内容

- install.sh の BASE_DIR 解決後、rm -rf bin の直前に asdf install を追加

## 背景 / 目的

fresh checkout で install.sh を実行したとき、手動で asdf install を呼ぶ手間をなくし、スクリプト単体でセットアップが完結するようにするため。